### PR TITLE
Allow Verbosity of Logging to be Configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-mock",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Connect middleware for providing mock responses to HTTP requests.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -18,10 +18,11 @@ module.exports = function(config) {
 
     return function(req, res, next) {
         var handlers = Object.keys(config)
+            .filter(function(key) { return !(/^@/).test(key); })
             .map(function(route) {
                 var defsPath = path.resolve(process.cwd(), config[route]),
                     defs = require(defsPath),
-                    httpMock = new HTTPMock(route);
+                    httpMock = new HTTPMock(route, { verbosity: config['@verbosity'] });
 
                 defs(httpMock);
                 // Remove the defs file after every request so the server does not need to be


### PR DESCRIPTION
to @sqmunson 

You can now place an `@verbosity` directive in the config object to adjust the amount of logging. An `@verbosity` of `0` will entirely disable logging.

Ex:

``` javascript
require('http-mock')({
    '/api/foo': 'foo.js',
    '/api/bar': 'bar.js',

    '@verbosity': 0
});
```
